### PR TITLE
Datasource templating

### DIFF
--- a/docs/rst/usage.rst
+++ b/docs/rst/usage.rst
@@ -56,3 +56,28 @@ Templating
 
 .. literalinclude:: ../../tests/usage/templating.py
 	:language: python
+
+Datasources
+===========
+
+Grafana recently added the datasource uid to the dashboard. This solves many problems, but does make migrating between instances a bit harder. ``grafanarmadillo`` provides 2 ways to make this easier. The first is to create your datasources with the ``Datasourcer``. This will give them a stable UID based on the name of the datasource, so the UID will match across instances.
+
+.. code:: python
+
+	from grafanarmadillo.datasourcer import Datasourcer
+	from grafanarmadillo.types import DatasourceInfo
+
+	dsinfo: DatasourceInfo = read_json_file("datasource.json")
+	datasourcer = Datasourcer(gfn)
+	datasourcer.put(dsinfo)
+
+The other way it to use a transformer built for migrating between instances. The ``DatasourceDashboardTransformer`` is built for switching between names and UIDs. This works like a standard dashboard transformer, which you can combine with other dashboard transformers
+
+.. code:: python
+
+	datasources_make_template = DatasourceDashboardTransformer([{'uid': original_uid, 'name': 'name'}]).use_name
+	datasources_make_dashboard = DatasourceDashboardTransformer([{'uid': new_uid, 'name': 'name'}]).use_uid
+
+	# with other DashboardTransformers
+	template_maker = combine_transformers(findreplace_make_template, datasources_make_template)
+	dashboard_maker = combine_transformers(findreplace_make_dashboard, datasources_make_dashboard)

--- a/src/grafanarmadillo/_util.py
+++ b/src/grafanarmadillo/_util.py
@@ -1,7 +1,6 @@
 from typing import Callable, Dict, List, TypeVar, Union
 
-from grafanarmadillo.types import DashboardContent, DashboardSearchResult
-
+from grafanarmadillo.types import DashboardContent, DashboardSearchResult, DatasourceInfo
 
 A = TypeVar("A")
 JSON = TypeVar("JSON", bound=Union[dict, list, str, int, float, bool, None])
@@ -10,7 +9,7 @@ JSON = TypeVar("JSON", bound=Union[dict, list, str, int, float, bool, None])
 def flat_map(f, xs):
 	"""
 	Flatmap: Map on a list and then merge the results.
-	
+
 	>>> and_reversed = lambda s: [s,s[::-1]]
 
 	>>> flat_map(and_reversed, [])
@@ -32,7 +31,7 @@ def flat_map(f, xs):
 def exactly_one(items: List[A], msg="did not find exactly one item") -> A:
 	"""
 	Throws if list does not contain exactly 1 item.
-	
+
 	>>> exactly_one([1])
 	1
 
@@ -53,7 +52,7 @@ def exactly_one(items: List[A], msg="did not find exactly one item") -> A:
 def project_dict(d: Dict, keys: set, inverse: bool = False) -> Dict:
 	"""
 	Select the given fields from a dictionary.
-	
+
 	>>> project_dict({'a': 1, 'b': 2}, set(['a']))
 	{'a': 1}
 
@@ -66,18 +65,19 @@ def project_dict(d: Dict, keys: set, inverse: bool = False) -> Dict:
 dashboard_meta_fields = set(["id", "uid", "title"])
 
 
-def project_dashboard_identity(
-	dashboardlike: Union[DashboardSearchResult, DashboardContent]
-) -> Dict:
+def project_dashboard_identity(dashboardlike: Union[DashboardSearchResult, DashboardContent]) -> Dict:
 	"""Project only the fields of a dashboard which are used for determining identity."""
 	return project_dict(dashboardlike, dashboard_meta_fields)
 
 
-def erase_dashboard_identity(
-	dashboardlike: Union[DashboardSearchResult, DashboardContent]
-) -> Dict:
+def erase_dashboard_identity(dashboardlike: Union[DashboardSearchResult, DashboardContent]) -> Dict:
 	"""Delete the fields of a dashboard which are used for determining identity."""
 	return project_dict(dashboardlike, dashboard_meta_fields, inverse=True)
+
+
+def extract_datasource_pk(datasource: DatasourceInfo):
+	"""Get the fields of a datasource used to compute its stable UID"""
+	return project_dict(datasource, {"name"})
 
 
 def map_json_strings(f: Callable[[str], str], obj: JSON) -> JSON:

--- a/src/grafanarmadillo/datasourcer.py
+++ b/src/grafanarmadillo/datasourcer.py
@@ -1,0 +1,51 @@
+import json
+from typing import Union
+from uuid import UUID, uuid5
+
+from grafana_api import GrafanaFace
+from grafana_api.grafana_api import GrafanaClientError
+
+from grafanarmadillo._util import extract_datasource_pk
+from grafanarmadillo.types import DatasourceInfo
+
+
+class Datasourcer(object):
+	"""Collection of methods for managing datasources."""
+
+	_UUID5_NS = UUID("eda3055a-6502-4701-990e-b5db7570372f")  # UUID5 requires a namespace
+
+	def __init__(self, api: GrafanaFace, _uuid5_ns: UUID = _UUID5_NS) -> None:
+		super().__init__()
+		self.api = api
+		self._uuid5_ns = _uuid5_ns
+
+	def put(self, dsinfo):
+		"""
+		Put a datasource, recomputing the uid
+		"""
+		target = self.datsource_uuid(dsinfo)
+		ds = dsinfo.copy()
+		ds["uid"] = target
+		if "version" in ds:
+			del ds["version"]
+
+		try:
+			existing = self.api.datasource.get_datasource_by_name(ds["name"])
+			target_id = existing["id"]
+			return self.api.datasource.update_datasource(target_id, ds)
+		except GrafanaClientError as e:
+			if e.status_code == 404:
+				return self.api.datasource.create_datasource(ds)
+			else:
+				raise
+
+	def get(self, dsinfo: DatasourceInfo):
+		"""Get a datasource"""
+		target = self.datsource_uuid(dsinfo)
+
+		print(target)
+		return self.api.datasource.api.GET("/datasources/uid/%s" % target)
+
+	def datsource_uuid(self, ds: DatasourceInfo) -> str:
+		dumped = json.dumps(extract_datasource_pk(ds), sort_keys=True)
+		return str(uuid5(self._uuid5_ns, dumped))

--- a/src/grafanarmadillo/datasourcer.py
+++ b/src/grafanarmadillo/datasourcer.py
@@ -1,5 +1,4 @@
 import json
-from typing import Union
 from uuid import UUID, uuid5
 
 from grafana_api import GrafanaFace

--- a/src/grafanarmadillo/templator.py
+++ b/src/grafanarmadillo/templator.py
@@ -1,5 +1,5 @@
 """Make and fill templates for dashboards."""
-from typing import Callable, Dict
+from typing import List, Callable, Dict
 
 from grafanarmadillo._util import (
 	map_json_strings,
@@ -10,6 +10,7 @@ from grafanarmadillo.types import (
 	DashboardContent,
 	DashboardPanel,
 	DashboardSearchResult,
+	DatasourceInfo,
 )
 
 
@@ -48,12 +49,10 @@ def combine_transformers(*transformers: DashboardTransformer) -> DashboardTransf
 	return _chained
 
 
-def panel_transformer(
-	f: Callable[[DashboardPanel], DashboardPanel]
-) -> DashboardTransformer:
+def panel_transformer(f: Callable[[DashboardPanel], DashboardPanel]) -> DashboardTransformer:
 	"""
 	Make DashboardTransformer which processes all panels in a dashboard.
-	
+
 	Will omit a dashboard if function returns None
 	"""
 
@@ -68,6 +67,46 @@ def panel_transformer(
 	return _panel_transformer
 
 
+class DatasourceDashboardTransformer:
+	def __init__(self, datasources: List[DatasourceInfo]):
+		self.by_name = {d["name"]: d for d in datasources}
+		self.by_uid = {d["uid"]: d for d in datasources}
+
+	def _modify_panel_datasources(self, f: Callable, panel):
+		targets = panel["targets"]
+		out = []
+		for t in targets:
+			if "datasource" in t:
+				d = t["datasource"]
+				t["datasource"] = f(d)
+				out.append(t)
+
+		panel["targets"] = out
+		return panel
+
+	def _use_name(self, panel):
+		def _do_add_name(d):
+			d["name"] = self.by_uid[d["uid"]]["name"]
+			del d["uid"]
+			return d
+
+		return self._modify_panel_datasources(_do_add_name, panel)
+
+	def _use_uid(self, panel):
+		def _do_rebuild_uid(d):
+			d["uid"] = self.by_name[d["name"]]["uid"]
+			del d["name"]
+			return d
+
+		return self._modify_panel_datasources(_do_rebuild_uid, panel)
+
+	def use_name(self, d: DashboardContent):
+		return panel_transformer(self._use_name)(d)
+
+	def use_uid(self, d: DashboardContent):
+		return panel_transformer(self._use_uid)(d)
+
+
 class Templator(object):
 	"""Collection of methods for filling and making templates."""
 
@@ -80,20 +119,14 @@ class Templator(object):
 		self.make_template = make_template
 		self.fill_template = fill_template
 
-	def make_template_from_dashboard(
-		self, dashboard: DashboardContent
-	) -> DashboardContent:
+	def make_template_from_dashboard(self, dashboard: DashboardContent) -> DashboardContent:
 		"""Convert a dashboard into a one ready for templating."""
 		new = dashboard.copy()
-		new = project_dict(
-			new, set(["id", "uid"]), inverse=True
-		)  # we don't erase the title so we can template it later
+		new = project_dict(new, set(["id", "uid"]), inverse=True)  # we don't erase the title so we can template it later
 
 		return self.make_template(new)
 
-	def make_dashboard_from_template(
-		self, dashboard_info: DashboardSearchResult, template: DashboardContent
-	) -> DashboardContent:
+	def make_dashboard_from_template(self, dashboard_info: DashboardSearchResult, template: DashboardContent) -> DashboardContent:
 		"""Inflate a template."""
 		new = template.copy()
 		new.update(project_dashboard_identity(dashboard_info))

--- a/src/grafanarmadillo/types.py
+++ b/src/grafanarmadillo/types.py
@@ -39,3 +39,6 @@ DashboardPanel = NewType("DashboardPanel", dict)
 
 
 FolderSearchResult = NewType("Folder", dict)
+
+
+DatasourceInfo = NewType("DatasourceInfo", dict)

--- a/tests/dashboard_with_datasource.json
+++ b/tests/dashboard_with_datasource.json
@@ -1,0 +1,127 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "graphite",
+            "uid": "f8c0b7a3-7d64-5ed8-a2fe-e6f517330dc2"
+          },
+          "refId": "A",
+          "target": "select this from that",
+          "textEditor": true
+        }
+      ],
+      "title": "Panel Title",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 34,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "New dashboard Copy",
+  "uid": "nErXDvCkzz",
+  "version": 1,
+  "weekStart": ""
+}

--- a/tests/datasource.json
+++ b/tests/datasource.json
@@ -1,6 +1,6 @@
 {
 	"id": 1,
-	"uid": "rqjvagH7z",
+	"uid": "f8c0b7a3-7d64-5ed8-a2fe-e6f517330dc2",
 	"orgId": 1,
 	"name": "Graphite",
 	"type": "graphite",
@@ -15,8 +15,11 @@
 	"basicAuthPassword": "",
 	"withCredentials": false,
 	"isDefault": true,
-	"jsonData": { "graphiteVersion": "1.1" },
+	"jsonData": {
+		"graphiteVersion": "1.1",
+		"timeout": 2
+	},
 	"secureJsonFields": {},
-	"version": 2,
+	"version": 3,
 	"readOnly": false
 }

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -1,0 +1,59 @@
+from grafanarmadillo._util import project_dict
+from grafanarmadillo.datasourcer import Datasourcer
+from tests.conftest import read_json_file
+
+
+class TestDatasources:
+	@staticmethod
+	def config_fields(d):
+		return project_dict(d, {"id", "uid", "version"}, inverse=True)
+
+	def test_put_datasource__new(self, rw_shared_grafana, unique):
+		"""Test that Datasourcer.put can create a new datasource"""
+		api = rw_shared_grafana[1]
+		datasourcer = Datasourcer(api)
+
+		dsinfo = read_json_file("datasource.json")
+		del dsinfo["uid"]
+		dsinfo["name"] = unique
+		datasourcer.put(dsinfo)
+
+		actual = api.datasource.get_datasource_by_name(unique)
+		assert actual["uid"] == datasourcer.datsource_uuid(dsinfo)
+		assert self.config_fields(actual) == self.config_fields(dsinfo)
+
+	def test_put_datasource__existing(self, rw_shared_grafana, unique):
+		"""Test that Datasourcer.put can update an existing datasource"""
+		api = rw_shared_grafana[1]
+		datasourcer = Datasourcer(api)
+
+		dsinfo = read_json_file("datasource.json")
+		del dsinfo["uid"]
+		dsinfo["name"] = unique
+		datasourcer.put(dsinfo)
+
+		changed_dsinfo = dsinfo.copy()
+		changed_dsinfo["type"] = "modified"
+		datasourcer.put(changed_dsinfo)
+
+		actual = api.datasource.get_datasource_by_name(unique)
+		assert actual["uid"] == datasourcer.datsource_uuid(dsinfo)
+		assert self.config_fields(actual) != self.config_fields(dsinfo)
+		assert self.config_fields(actual) == self.config_fields(changed_dsinfo)
+
+	def test_get_datasource(self, rw_shared_grafana, unique):
+		api = rw_shared_grafana[1]
+		datasourcer = Datasourcer(api)
+
+		name = unique[:8]  # just to make sure that we're not dependent on the name
+
+		dsinfo = read_json_file("datasource.json")
+		dsinfo["name"] = name
+
+		uid = datasourcer.datsource_uuid(dsinfo)
+		dsinfo["uid"] = uid
+		api.datasource.create_datasource(dsinfo)
+		# ---
+		result = datasourcer.get({"name": name})
+		assert result["name"] == name
+		assert result["uid"] == datasourcer.datsource_uuid(result)

--- a/tests/test_templator.py
+++ b/tests/test_templator.py
@@ -154,8 +154,16 @@ class TestDatasourceTransformer:
 		assert ds["uid"] == datasource["uid"]
 		assert "name" not in ds
 
-	def test_uid_intermediate(self, unique):
-		...
-
 	def test_name_intermediate(self, unique):
-		...
+		original = read_json_file("dashboard_with_datasource.json")
+		original_uid = original["panels"][0]["targets"][0]["datasource"]["uid"]
+
+		t0 = DatasourceDashboardTransformer([{'uid': original_uid, 'name': 'name'}]).use_name
+		t1 = DatasourceDashboardTransformer([{'uid': 'uid1', 'name': 'name'}]).use_uid
+
+		t = combine_transformers(t0, t1)
+
+		r = t(original)
+
+		ds = r["panels"][0]["targets"][0]["datasource"]
+		assert ds['uid'] == 'uid1'


### PR DESCRIPTION
Grafana recently added the UID to panel datasource definitions. This MR helps template those in 2 ways:
- create datasources with a consistent UID based on the name
- provide templators for swapping UIDs between instances based on the name